### PR TITLE
Add support for :path option to S3Store

### DIFF
--- a/lib/sitemapper/store/s3_store.ex
+++ b/lib/sitemapper/store/s3_store.ex
@@ -10,7 +10,7 @@ defmodule Sitemapper.S3Store do
       {:acl, :public_read}
     ]
 
-    ExAws.S3.put_object(bucket, filename, body, props)
+    ExAws.S3.put_object(bucket, key(filename, config), body, props)
     |> ExAws.request!()
 
     :ok
@@ -21,6 +21,13 @@ defmodule Sitemapper.S3Store do
       "application/x-gzip"
     else
       "application/xml"
+    end
+  end
+
+  defp key(filename, config) do
+    case Keyword.get(config, :path, nil) do
+      nil -> filename
+      path -> Path.join([path, filename])
     end
   end
 end


### PR DESCRIPTION
Thank you for creating great package!

Currently sitemap is uploaded to bucket top-level on S3. I would like to change this to upload to `bucket/path/to/sitemaps/sitemap.xml.gz`. This PR adds support for `:path` option to `Sitemapper.S3Store`.

I know it is called prefix but it is confusing because already `:suffix` option exists. `:path` option is handled in `FileStore` so I picked the same terminology. Please tell me If there is better name.

Thanks.