### PR TITLE
Add inets and ssl to extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Sitemapper.MixProject do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :inets, :ssl]
     ]
   end
 


### PR DESCRIPTION
`Sitemapper.Pinger.ping/1` uses `:httpc` but it is not available on releases. To fix that we have to tell elixir that we need them.